### PR TITLE
Verify startsession hook and mise installation

### DIFF
--- a/tests/integration/test_session_hooks.py
+++ b/tests/integration/test_session_hooks.py
@@ -35,15 +35,20 @@ class TestSessionStartHook:
         mise_check = subprocess.run(
             ["which", "mise"],
             capture_output=True,
+            text=True,
         )
 
         if mise_check.returncode != 0:
             pytest.skip("mise not installed in test environment - cannot test early exit")
 
+        # Get mise's actual directory to include in PATH
+        mise_path = mise_check.stdout.strip()
+        mise_dir = str(Path(mise_path).parent)
+
         # Run with mise in PATH
         result = subprocess.run(
             [str(script_path)],
-            env={"CLAUDE_CODE_REMOTE": "true", "PATH": "/usr/local/bin:/usr/bin:/bin"},
+            env={"CLAUDE_CODE_REMOTE": "true", "PATH": f"{mise_dir}:/usr/local/bin:/usr/bin:/bin"},
             capture_output=True,
             text=True,
         )


### PR DESCRIPTION
The test_script_exits_early_when_mise_already_installed test was hanging because it used a hardcoded PATH that didn't include where mise is actually installed (/opt/node22/bin).

The script would then attempt to install mise via npm instead of recognizing it was already installed, causing the test to timeout.

Fix: Dynamically determine mise's actual directory and include it in the test PATH so the script correctly detects mise is installed.